### PR TITLE
[Feat] 데이터 생성 API에 평가 및 피드백 기능 추가 + 새로운 entity세팅

### DIFF
--- a/src/main/generated/com/example/SchoolLunchReport/product/evaluation/entity/QEvaluation.java
+++ b/src/main/generated/com/example/SchoolLunchReport/product/evaluation/entity/QEvaluation.java
@@ -1,0 +1,53 @@
+package com.example.SchoolLunchReport.product.evaluation.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QEvaluation is a Querydsl query type for Evaluation
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QEvaluation extends EntityPathBase<Evaluation> {
+
+    private static final long serialVersionUID = -61491607L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QEvaluation evaluation1 = new QEvaluation("evaluation1");
+
+    public final StringPath evaluation = createString("evaluation");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.example.SchoolLunchReport.product.menu.domain.entity.QMenu menu;
+
+    public QEvaluation(String variable) {
+        this(Evaluation.class, forVariable(variable), INITS);
+    }
+
+    public QEvaluation(Path<? extends Evaluation> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QEvaluation(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QEvaluation(PathMetadata metadata, PathInits inits) {
+        this(Evaluation.class, metadata, inits);
+    }
+
+    public QEvaluation(Class<? extends Evaluation> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.menu = inits.isInitialized("menu") ? new com.example.SchoolLunchReport.product.menu.domain.entity.QMenu(forProperty("menu")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/SchoolLunchReport/product/menu/domain/entity/QMenu.java
+++ b/src/main/generated/com/example/SchoolLunchReport/product/menu/domain/entity/QMenu.java
@@ -21,8 +21,6 @@ public class QMenu extends EntityPathBase<Menu> {
 
     public final DatePath<java.time.LocalDate> date = createDate("date", java.time.LocalDate.class);
 
-    public final StringPath evaluation = createString("evaluation");
-
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final EnumPath<com.example.SchoolLunchReport.product.menu.domain.type.MealType> mealType = createEnum("mealType", com.example.SchoolLunchReport.product.menu.domain.type.MealType.class);

--- a/src/main/generated/com/example/SchoolLunchReport/statistics/domain/feedback/entity/QFeedBack.java
+++ b/src/main/generated/com/example/SchoolLunchReport/statistics/domain/feedback/entity/QFeedBack.java
@@ -27,6 +27,8 @@ public class QFeedBack extends EntityPathBase<FeedBack> {
     //inherited
     public final DatePath<java.time.LocalDate> createdAt = _super.createdAt;
 
+    public final StringPath evaluation = createString("evaluation");
+
     public final com.example.SchoolLunchReport.product.FoodMenu.domain.entity.QFoodMenu foodMenu;
 
     public final NumberPath<Long> id = createNumber("id", Long.class);

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DataControllerDocs.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DataControllerDocs.java
@@ -1,8 +1,6 @@
 package com.example.SchoolLunchReport.dummy.dataset.controller;
-
-
 import com.example.SchoolLunchReport.dummy.dataset.dto.FeedBackDTO;
-import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsDTO;
+import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsAndEvaluationDTO;
 import com.example.SchoolLunchReport.global.response.ApiResponse;
 import com.example.SchoolLunchReport.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
@@ -14,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
-
 @Tag(name = "데이터 초기화 관련 API")
 public interface DataControllerDocs {
 
@@ -22,8 +19,8 @@ public interface DataControllerDocs {
     ResponseEntity<Map<String, Object>> createFoodData(@RequestBody List<Food> foods);
 
     @Operation(summary = "메뉴 초기화")
-    ResponseEntity<Map<String, Object>> createMenuWithFoods(
-        @RequestBody List<MenuWithFoodsDTO> menuWithFoodsList);
+    ResponseEntity<Map<String, Object>> createMenuWithFoodsAndEvaluation(
+        @RequestBody List<MenuWithFoodsAndEvaluationDTO> menuWithFoodsList);
 
     @Operation(summary = "피드백 초기화")
     ResponseEntity<Map<String, Object>> createFeedback(

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DatasetController.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DatasetController.java
@@ -1,8 +1,7 @@
 package com.example.SchoolLunchReport.dummy.dataset.controller;
-
 import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TEAM_URL;
 import com.example.SchoolLunchReport.dummy.dataset.dto.FeedBackDTO;
-import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsDTO;
+import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsAndEvaluationDTO;
 import com.example.SchoolLunchReport.dummy.dataset.service.DatasetService;
 import com.example.SchoolLunchReport.global.response.ApiResponse;
 import com.example.SchoolLunchReport.global.response.type.SuccessType;
@@ -24,15 +23,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(ANALYTICS_TEAM_URL + "/dataset")
 public class DatasetController implements DataControllerDocs {
-
     private final DatasetService datasetService;
     private final StatisticsFacade statisticsFacade;
-
     @PostMapping("/createfood")
     public ResponseEntity<Map<String, Object>> createFoodData(@RequestBody List<Food> foods) {
         int count = datasetService.createFoodData(foods);
@@ -41,17 +37,15 @@ public class DatasetController implements DataControllerDocs {
         response.put("count", count);
         return ResponseEntity.ok(response);
     }
-
     @PostMapping("/createmenu")
-    public ResponseEntity<Map<String, Object>> createMenuWithFoods(
-        @RequestBody List<MenuWithFoodsDTO> menuWithFoodsList) {
-        int count = datasetService.createMenuWithFoods(menuWithFoodsList);
+    public ResponseEntity<Map<String, Object>> createMenuWithFoodsAndEvaluation(
+            @RequestBody List<MenuWithFoodsAndEvaluationDTO> menuWithFoodsAndEvaluationList) {
+        int count = datasetService.createMenuWithFoodsAndEvaluation(menuWithFoodsAndEvaluationList);
         Map<String, Object> response = new HashMap<>();
-        response.put("message", "메뉴 및 푸드메뉴 데이터가 성공적으로 생성되었습니다..");
+        response.put("message", "메뉴, 푸드메뉴 및 평가 데이터가 성공적으로 생성되었습니다.");
         response.put("count", count);
         return ResponseEntity.ok(response);
     }
-
     @PostMapping("/createfeedback")
     public ResponseEntity<Map<String, Object>> createFeedback(
         @RequestBody List<FeedBackDTO> feedbacks) {
@@ -61,7 +55,6 @@ public class DatasetController implements DataControllerDocs {
         response.put("count", count);
         return ResponseEntity.ok(response);
     }
-
     @PostMapping("/createfeedback/random")
     public ResponseEntity<Map<String, Object>> createRandomFeedback(LocalDate registerDate) {
         int count = datasetService.createRandomFeedback(registerDate);
@@ -70,13 +63,11 @@ public class DatasetController implements DataControllerDocs {
         response.put("count", count);
         return ResponseEntity.ok(response);
     }
-
     @GetMapping("/allmenu")
     public ResponseEntity<List<Menu>> getAllMenus() {
         List<Menu> menus = datasetService.getAllMenus();
         return ResponseEntity.ok(menus);
     }
-
     @Override
     @PostMapping("/rank")
     public ApiResponse<?> createRank(
@@ -86,7 +77,6 @@ public class DatasetController implements DataControllerDocs {
         statisticsFacade.calculateAndSaveRank(periodType, registerDate);
         return ApiResponse.success(SuccessType.SUCCESS);
     }
-
     @Override
     @GetMapping("/rank")
     public ApiResponse<?> getRankList(LocalDate registerDate, PeriodType periodType) {
@@ -99,8 +89,6 @@ public class DatasetController implements DataControllerDocs {
         List<DesiredFood> desiredFoods = datasetService.createDesiredFoods();
         return ApiResponse.success(SuccessType.SUCCESS,desiredFoods);
     }
-
-
     @GetMapping("/test")
     public ResponseEntity<Map<String, String>> testEndpoint() {
         Map<String, String> response = new HashMap<>();

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/dto/FeedBackDTO.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/dto/FeedBackDTO.java
@@ -9,4 +9,5 @@ public class FeedBackDTO {
 
     private Long foodMenuId;
     private Double score;
+    private String evaluation;
 }

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/dto/MenuWithFoodsAndEvaluationDTO.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/dto/MenuWithFoodsAndEvaluationDTO.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
-public class MenuWithFoodsDTO {
+public class MenuWithFoodsAndEvaluationDTO {
     private LocalDate date;
     private MealType mealType;
     private String evaluation;

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/service/DatasetService.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/service/DatasetService.java
@@ -1,11 +1,12 @@
 package com.example.SchoolLunchReport.dummy.dataset.service;
-
 import com.example.SchoolLunchReport.client.LLMClient;
 import com.example.SchoolLunchReport.client.dto.request.AdjustMenuNameRequestDto;
 import com.example.SchoolLunchReport.dummy.dataset.dto.FeedBackDTO;
-import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsDTO;
+import com.example.SchoolLunchReport.dummy.dataset.dto.MenuWithFoodsAndEvaluationDTO;
 import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
 import com.example.SchoolLunchReport.product.FoodMenu.repository.FoodMenuJpaRepository;
+import com.example.SchoolLunchReport.product.evaluation.entity.Evaluation;
+import com.example.SchoolLunchReport.product.evaluation.repository.EvaluationJpaRepository;
 import com.example.SchoolLunchReport.statistics.domain.desired.entity.DesiredFood;
 import com.example.SchoolLunchReport.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.product.food.domain.type.Category;
@@ -25,20 +26,17 @@ import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 @Service
 @RequiredArgsConstructor
 public class DatasetService {
-
     private final FoodJpaRepository foodJpaRepository;
     private final FoodMenuJpaRepository foodMenuJpaRepository;
     private final MenuJpaRepository menuJpaRepository;
     private final FeedBackJpaRepo feedBackJpaRepo;
     private final LLMClient llmClient;
     private final DesiredFoodJpaRepo desiredFoodJpaRepo;
+    private final EvaluationJpaRepository evaluationJpaRepository;
     private final RankImpl rankImpl;
-
-
     @Transactional
     public int createFoodData(List<Food> foods) {
         List<Food> savedFoods = foodJpaRepository.saveAll(foods);
@@ -46,9 +44,10 @@ public class DatasetService {
     }
 
     @Transactional
-    public int createMenuWithFoods(List<MenuWithFoodsDTO> menuWithFoodsList) {
+    public int createMenuWithFoodsAndEvaluation(List<MenuWithFoodsAndEvaluationDTO> menuWithFoodsAndEvaluationList) {
         List<Menu> menus = new ArrayList<>();
         List<FoodMenu> foodMenus = new ArrayList<>();
+        List<Evaluation> evaluations = new ArrayList<>();
         Map<Category, List<Food>> foodsByCategory = new HashMap<>();
         for (Category category : Category.values()) {
             foodsByCategory.put(category, foodJpaRepository.findByCategory(category));
@@ -56,20 +55,24 @@ public class DatasetService {
         for (Category category : Category.values()) {
             if (foodsByCategory.get(category).isEmpty()) {
                 throw new IllegalStateException(
-                    category + " 카테고리에 음식이 없습니다. 모든 카테고리에 최소 한 개 이상의 음식을 생성해주세요.");
+                        category + " 카테고리에 음식이 없습니다. 모든 카테고리에 최소 한 개 이상의 음식을 생성해주세요.");
             }
         }
-        for (MenuWithFoodsDTO dto : menuWithFoodsList) {
+        for (MenuWithFoodsAndEvaluationDTO dto : menuWithFoodsAndEvaluationList) {
             Menu menu = new Menu();
             setField(menu, "date", dto.getDate());
             setField(menu, "mealType", dto.getMealType());
-            setField(menu, "evaluation", dto.getEvaluation());
-
             Menu savedMenu = menuJpaRepository.save(menu);
+            if (dto.getEvaluation() != null && !dto.getEvaluation().trim().isEmpty()) {
+                Evaluation evaluation = new Evaluation();
+                evaluation.setMenu(savedMenu);
+                evaluation.setEvaluation(dto.getEvaluation());
+                evaluations.add(evaluation);
+            }
             for (Category category : Category.values()) {
                 List<Food> foodsInCategory = foodsByCategory.get(category);
                 Food selectedFood = foodsInCategory.get(
-                    new Random().nextInt(foodsInCategory.size()));
+                        new Random().nextInt(foodsInCategory.size()));
                 FoodMenu foodMenu = new FoodMenu();
                 foodMenu.setMenu(savedMenu);
                 foodMenu.setFood(selectedFood);
@@ -77,7 +80,8 @@ public class DatasetService {
             }
         }
         foodMenuJpaRepository.saveAll(foodMenus);
-        return menuWithFoodsList.size();
+        if (!evaluations.isEmpty()) evaluationJpaRepository.saveAll(evaluations);
+        return menuWithFoodsAndEvaluationList.size();
     }
 
     private void setField(Object object, String fieldName, Object value) {
@@ -106,6 +110,7 @@ public class DatasetService {
             FeedBack feedBack = FeedBack.builder()
                 .score(dto.getScore())
                 .foodMenu(foodMenu)
+                .evaluation(dto.getEvaluation())
                 .build();
             setField(feedBack, "foodMenu", foodMenu);
             feedBackList.add(feedBack);

--- a/src/main/java/com/example/SchoolLunchReport/product/evaluation/entity/Evaluation.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/evaluation/entity/Evaluation.java
@@ -1,0 +1,21 @@
+package com.example.SchoolLunchReport.product.evaluation.entity;
+import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Setter
+@Getter
+public class Evaluation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+    private String evaluation;
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/evaluation/repository/EvaluationJpaRepository.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/evaluation/repository/EvaluationJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.SchoolLunchReport.product.evaluation.repository;
+import com.example.SchoolLunchReport.product.evaluation.entity.Evaluation;
+import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+public interface EvaluationJpaRepository extends JpaRepository<Evaluation, Long> {
+    List<Evaluation> findByMenu(Menu menu);
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/menu/domain/entity/Menu.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/menu/domain/entity/Menu.java
@@ -1,19 +1,15 @@
 package com.example.SchoolLunchReport.product.menu.domain.entity;
-
 import com.example.SchoolLunchReport.product.menu.domain.type.MealType;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
 import lombok.Getter;
-
 @Entity
 @Getter
 public class Menu {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private LocalDate date;
     private MealType mealType;
-    private String evaluation;
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/feedback/entity/FeedBack.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/feedback/entity/FeedBack.java
@@ -1,5 +1,4 @@
 package com.example.SchoolLunchReport.statistics.domain.feedback.entity;
-
 import com.example.SchoolLunchReport.global.common.BaseTimeEntity;
 import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
 import com.example.SchoolLunchReport.product.food.domain.entity.Food;
@@ -12,26 +11,24 @@ import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 @Entity
 @Getter
 @NoArgsConstructor
 public class FeedBack extends BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Double score;
     @ManyToOne
     private FoodMenu foodMenu;
-
+    private String evaluation;
     @Builder
-    public FeedBack(Double score, FoodMenu foodMenu, LocalDate createdAt) {
+    public FeedBack(Double score, FoodMenu foodMenu, String evaluation, LocalDate createdAt) {
         this.score = score;
         this.foodMenu = foodMenu;
         this.createdAt = createdAt;
+        this.evaluation = evaluation;
     }
-
     public Food getFood() {
         return foodMenu.getFood();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: team03-be
 
   datasource:
-    url: jdbc:mysql://msa-service-team03-eks.c3kygsge2own.ap-northeast-2.rds.amazonaws.com:3306/paper1?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-    username: admin
-    password: msa_service
+    url: jdbc:mysql://paper-data-crawling.cl64kkugmebl.ap-northeast-2.rds.amazonaws.com:3306/paper1?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+    username: paper
+    password: paper)paper123
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
# PR: 데이터 생성 API에 평가 및 피드백 기능 추가
## 변경 사항 요약
기존의 메뉴 및 음식 데이터 생성 API를 확장하여 평가(evaluation) 및 피드백(feedback) 데이터도 함께 생성할 수 있도록 기능을 추가

## 주요 변경 내용

### 1. DTO 클래스 추가
- "MenuWithFoodsAndEvaluationDTO" 클래스를 새로 추가 -> 평가 데이터를 함께 처리할 수 있도록 함
- 관련 `DataControllerDocs` 문서도 수정

### 2. 데이터 저장 방식 수정
- 데이터베이스 스키마에 맞게 메뉴, 음식, 평가, 피드백 데이터를 연결하여 저장하는 방식으로 변경

### 3. 엔티티 구조 업데이트
- DB 구조에 맞게 `Food`, `Menu`, `FoodMenu`, `Evaluation`, `Feedback` 엔티티 관계 설정
- Evaluation entity추가

### 4. API 기능 확장
- 하나의 API 호출로 메뉴, 음식 메뉴, 평가, 피드백 데이터를 동시에 생성할 수 있도록 기능 추가

## 테스트 결과
- Postman을 통한 API 테스트 완료