### PR TITLE
[Feat] 급식 분석 AI 리포트 기능 추가 - llm api django 프로젝트 연결 및 contrllor, dto, …

### DIFF
--- a/src/main/java/com/example/SchoolLunchReport/aireport/controller/AiReportController.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/controller/AiReportController.java
@@ -1,0 +1,23 @@
+package com.example.SchoolLunchReport.aireport.controller;
+import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TEAM_URL;
+import com.example.SchoolLunchReport.aireport.dto.AiReportRequestDto;
+import com.example.SchoolLunchReport.aireport.dto.AiReportResponseDto;
+import com.example.SchoolLunchReport.aireport.service.AiReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ANALYTICS_TEAM_URL + "/aireport")
+@RequiredArgsConstructor
+public class AiReportController {
+    private final AiReportService aiReportService;
+    @PostMapping("/generate")
+    public ResponseEntity<AiReportResponseDto> generateReport(@RequestBody AiReportRequestDto requestDto) {
+        AiReportResponseDto responseDto = aiReportService.generateReport(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportDataDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportDataDto.java
@@ -1,0 +1,18 @@
+package com.example.SchoolLunchReport.aireport.dto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiReportDataDto {
+    private String period_data;
+    private String menu_evaluation_data;
+    private List<String> feed_back_evaluation_data;
+    private Double average_calorie_data;
+    private Double average_score_data;
+    private String all_food_name_data;
+}

--- a/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.SchoolLunchReport.aireport.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class AiReportRequestDto {
+    private LocalDate start_date;
+    private LocalDate end_date;
+}

--- a/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.SchoolLunchReport.aireport.dto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiReportResponseDto {
+    private String message;
+    private String error;
+    private String report;
+}

--- a/src/main/java/com/example/SchoolLunchReport/aireport/service/AiReportService.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/service/AiReportService.java
@@ -1,0 +1,244 @@
+package com.example.SchoolLunchReport.aireport.service;
+import com.example.SchoolLunchReport.aireport.dto.AiReportDataDto;
+import com.example.SchoolLunchReport.aireport.dto.AiReportRequestDto;
+import com.example.SchoolLunchReport.aireport.dto.AiReportResponseDto;
+import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
+import com.example.SchoolLunchReport.product.evaluation.entity.Evaluation;
+import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
+import com.example.SchoolLunchReport.statistics.domain.feedback.entity.FeedBack;
+import com.example.SchoolLunchReport.product.FoodMenu.repository.FoodMenuJpaRepository;
+import com.example.SchoolLunchReport.product.evaluation.repository.EvaluationJpaRepository;
+import com.example.SchoolLunchReport.product.food.repository.FoodJpaRepository;
+import com.example.SchoolLunchReport.product.menu.repository.MenuJpaRepository;
+import com.example.SchoolLunchReport.statistics.repository.FeedBackJpaRepo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.springframework.http.*;
+
+@Service
+@RequiredArgsConstructor
+public class AiReportService {
+    private final MenuJpaRepository menuJpaRepository;
+    private final EvaluationJpaRepository evaluationJpaRepository;
+    private final FoodMenuJpaRepository foodMenuJpaRepository;
+    private final FeedBackJpaRepo feedBackJpaRepository;
+    private final FoodJpaRepository foodJpaRepository;
+    private final ObjectMapper objectMapper;
+    @Qualifier("aiReportRestTemplate")
+    private final RestTemplate restTemplate;
+
+    private static final int MAX_DATA_COUNT = 100;
+
+    public AiReportResponseDto generateReport(AiReportRequestDto requestDto) {
+        try {
+            List<Menu> menus = menuJpaRepository.findByDateBetween(requestDto.getStart_date(), requestDto.getEnd_date());
+
+            if (menus.isEmpty()) {
+                return AiReportResponseDto.builder()
+                        .error("해당 기간 동안의 학생식당 데이터가 존재하지 않습니다")
+                        .build();
+            }
+
+            String periodData = requestDto.getStart_date().format(DateTimeFormatter.ISO_DATE) +
+                    "~" +
+                    requestDto.getEnd_date().format(DateTimeFormatter.ISO_DATE);
+
+            String menuEvaluationData = getFormattedMenuEvaluationData(menus);
+
+            List<String> feedBackEvaluationData = getFeedbackEvaluationData(menus);
+
+            Double averageCalorieData = calculateAverageCalorieData(menus);
+            Double averageScoreData = calculateAverageScoreData(menus);
+            String allFoodNameData = getAllFoodNameData(menus);
+
+            AiReportDataDto reportData = AiReportDataDto.builder()
+                    .period_data(periodData)
+                    .menu_evaluation_data(menuEvaluationData)
+                    .feed_back_evaluation_data(feedBackEvaluationData)
+                    .average_calorie_data(averageCalorieData)
+                    .average_score_data(averageScoreData)
+                    .all_food_name_data(allFoodNameData)
+                    .build();
+
+            return sendReportToDjango(reportData);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return AiReportResponseDto.builder()
+                    .error("Error generating report: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    private String getFormattedMenuEvaluationData(List<Menu> menus) {
+        List<String> evaluationList = new ArrayList<>();
+        int count = 1;
+
+        for (Menu menu : menus) {
+            List<Evaluation> evaluations = evaluationJpaRepository.findByMenu(menu);
+            for (Evaluation evaluation : evaluations) {
+                if (evaluation.getEvaluation() != null && !evaluation.getEvaluation().isEmpty()) {
+                    evaluationList.add(String.format("%d번 평가: %s", count++, evaluation.getEvaluation()));
+                }
+            }
+        }
+
+        if (evaluationList.isEmpty()) return "평가 데이터가 없습니다.";
+
+        if (evaluationList.size() > MAX_DATA_COUNT) {
+            System.out.println("평가 데이터가 " + evaluationList.size() + "개로 제한을 초과하여 " + MAX_DATA_COUNT + "개로 제한합니다.");
+            Collections.shuffle(evaluationList);
+            evaluationList = evaluationList.subList(0, MAX_DATA_COUNT);
+
+            List<String> renumberedList = new ArrayList<>();
+            for (int i = 0; i < evaluationList.size(); i++) {
+                String evaluation = evaluationList.get(i);
+                String content = evaluation.substring(evaluation.indexOf("번 평가: ") + 6);
+                renumberedList.add(String.format("%d번 평가: %s", (i + 1), content));
+            }
+            evaluationList = renumberedList;
+        }
+
+        return String.join(", ", evaluationList);
+    }
+
+    private List<String> getFeedbackEvaluationData(List<Menu> menus) {
+        List<String> feedbackList = new ArrayList<>();
+
+        for (Menu menu : menus) {
+            List<FoodMenu> foodMenus = foodMenuJpaRepository.findByMenu(menu);
+            for (FoodMenu foodMenu : foodMenus) {
+                List<FeedBack> feedBacks = feedBackJpaRepository.findByFoodMenu(foodMenu);
+                for (FeedBack feedBack : feedBacks) {
+                    if (feedBack.getFood() != null && feedBack.getScore() != null) {
+                        String feedback = String.format("%s에 대한 평가 = 별점(5점만점): %.1f | 리뷰: %s",
+                                feedBack.getFood().getName(),
+                                feedBack.getScore(),
+                                feedBack.getEvaluation() != null ? feedBack.getEvaluation() : "");
+                        feedbackList.add(feedback);
+                    }
+                }
+            }
+        }
+
+        if (feedbackList.size() > MAX_DATA_COUNT) {
+            System.out.println("피드백 데이터가 " + feedbackList.size() + "개로 제한을 초과하여 " + MAX_DATA_COUNT + "개로 제한합니다.");
+            Collections.shuffle(feedbackList);
+            feedbackList = feedbackList.subList(0, MAX_DATA_COUNT);
+        }
+
+        return feedbackList;
+    }
+
+    private Double calculateAverageCalorieData(List<Menu> menus) {
+        double totalCalories = 0;
+        int totalDays = 0;
+
+        Map<LocalDate, List<Menu>> menusByDate = menus.stream()
+                .collect(Collectors.groupingBy(Menu::getDate));
+
+        for (Map.Entry<LocalDate, List<Menu>> entry : menusByDate.entrySet()) {
+            double dailyCalories = 0;
+            for (Menu menu : entry.getValue()) {
+                List<FoodMenu> foodMenus = foodMenuJpaRepository.findByMenu(menu);
+                for (FoodMenu foodMenu : foodMenus) {
+                    if (foodMenu.getFood() != null && foodMenu.getFood().getCalorie() != null) {
+                        dailyCalories += foodMenu.getFood().getCalorie();
+                    }
+                }
+            }
+            totalCalories += dailyCalories;
+            totalDays++;
+        }
+
+        return totalDays > 0 ? totalCalories / totalDays : 0;
+    }
+
+    private Double calculateAverageScoreData(List<Menu> menus) {
+        double totalScore = 0;
+        int scoreCount = 0;
+
+        for (Menu menu : menus) {
+            List<FoodMenu> foodMenus = foodMenuJpaRepository.findByMenu(menu);
+            for (FoodMenu foodMenu : foodMenus) {
+                List<FeedBack> feedBacks = feedBackJpaRepository.findByFoodMenu(foodMenu);
+                for (FeedBack feedBack : feedBacks) {
+                    if (feedBack.getScore() != null) {
+                        totalScore += feedBack.getScore();
+                        scoreCount++;
+                    }
+                }
+            }
+        }
+        return scoreCount > 0 ? totalScore / scoreCount : 0;
+    }
+
+    private String getAllFoodNameData(List<Menu> menus) {
+        Set<String> uniqueFoodNames = new HashSet<>();
+        for (Menu menu : menus) {
+            List<FoodMenu> foodMenus = foodMenuJpaRepository.findByMenu(menu);
+            for (FoodMenu foodMenu : foodMenus) {
+                if (foodMenu.getFood() != null && foodMenu.getFood().getName() != null) {
+                    uniqueFoodNames.add(foodMenu.getFood().getName());
+                }
+            }
+        }
+        return String.join(",", uniqueFoodNames);
+    }
+
+    private AiReportResponseDto sendReportToDjango(AiReportDataDto reportData) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+            Map<String, Object> requestMap = new HashMap<>();
+
+            requestMap.put("period_data", reportData.getPeriod_data());
+            requestMap.put("menu_evaluation_data", reportData.getMenu_evaluation_data());
+            requestMap.put("feed_back_evaluation_data", reportData.getFeed_back_evaluation_data());
+            requestMap.put("average_calorie_data", reportData.getAverage_calorie_data());
+            requestMap.put("average_score_data", reportData.getAverage_score_data());
+            requestMap.put("all_food_name_data", reportData.getAll_food_name_data());
+
+            String jsonBody = objectMapper.writeValueAsString(requestMap);
+            System.out.println("Sending JSON to Django: " + jsonBody);
+
+            HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
+
+            String djangoUrl = "http://k8s-msaservices-7d023f0bb9-676035063.ap-northeast-2.elb.amazonaws.com/api/team3/llmchatbot/create_report/";
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    djangoUrl,
+                    HttpMethod.POST,
+                    requestEntity,
+                    Map.class
+            );
+
+            System.out.println("Response from Django: " + response.getBody());
+
+            String message = (String) response.getBody().get("message");
+            String report = (String) response.getBody().get("report");
+
+            return AiReportResponseDto.builder()
+                    .message(message)
+                    .report(report)
+                    .build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return AiReportResponseDto.builder()
+                    .error("Error sending report to Django: " + e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/SchoolLunchReport/global/config/RestTemplateConfig.java
@@ -1,0 +1,34 @@
+package com.example.SchoolLunchReport.global.config;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+import java.nio.charset.StandardCharsets;
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate aiReportRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper());
+
+        StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
+
+        restTemplate.getMessageConverters().clear();
+        restTemplate.getMessageConverters().add(converter);
+        restTemplate.getMessageConverters().add(stringConverter);
+
+        return restTemplate;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/FoodMenu/repository/FoodMenuJpaRepository.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/FoodMenu/repository/FoodMenuJpaRepository.java
@@ -1,7 +1,11 @@
 package com.example.SchoolLunchReport.product.FoodMenu.repository;
 import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
+import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 @Repository
 public interface FoodMenuJpaRepository extends JpaRepository<FoodMenu, Long> {
+    List<FoodMenu> findByMenu(Menu menu);
 }

--- a/src/main/java/com/example/SchoolLunchReport/product/menu/repository/MenuJpaRepository.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/menu/repository/MenuJpaRepository.java
@@ -2,6 +2,11 @@ package com.example.SchoolLunchReport.product.menu.repository;
 import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 @Repository
 public interface MenuJpaRepository extends JpaRepository<Menu, Long> {
+    // 시작일~종료일 사이의 모든 메뉴 조회
+    List<Menu> findByDateBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
@@ -1,7 +1,5 @@
 package com.example.SchoolLunchReport.statistics.controller;
-
 import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TEAM_URL;
-
 import com.example.SchoolLunchReport.global.response.ApiResponse;
 import com.example.SchoolLunchReport.global.response.type.SuccessType;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedRankMenuResponseDto;

--- a/src/main/java/com/example/SchoolLunchReport/statistics/repository/FeedBackJpaRepo.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/repository/FeedBackJpaRepo.java
@@ -1,5 +1,6 @@
 package com.example.SchoolLunchReport.statistics.repository;
 
+import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
 import com.example.SchoolLunchReport.statistics.domain.feedback.entity.FeedBack;
 import java.time.LocalDate;
 import java.util.List;
@@ -8,10 +9,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedBackJpaRepo extends JpaRepository<FeedBack, Long> {
-
     List<FeedBack> findByCreatedAtBetween(LocalDate createdAt, LocalDate createdAt2);
-
     boolean existsByFoodMenuId(Long foodMenuId);
-
     List<FeedBack> findByCreatedAt(LocalDate startDate);
+    // 특정 FoodMenu의 모든 피드백 조회
+    List<FeedBack> findByFoodMenu(FoodMenu foodMenu);
 }


### PR DESCRIPTION
# 급식 분석 AI 리포트 기능 추가

## 개요
학교 급식 데이터를 분석하고 AI 기반 보고서를 생성하는 기능을 추가. -> 특정 기간의 급식 데이터(메뉴, 평가, 피드백 등)를 수집하여 분석팀의 Django 서버로 전송 & 생성된 마크다운 보고서 반환기능

## 추가된 클래스 및 인터페이스

### 컨트롤러
- **AiReportController**: 보고서 생성 API 엔드포인트 제공 (`/api/team3/analytics/aireport/generate`)

### 서비스
- **AiReportService**: 급식 데이터 수집, 가공 및 Django 서버와의 통신 담당

### DTO
- **AiReportRequestDto**: 보고서 생성 요청 데이터(시작 날짜, 종료 날짜) 전달
- **AiReportResponseDto**: 응답 데이터 및 생성된 마크다운 보고서 포함
- **AiReportDataDto**: Django 서버로 전송할 데이터 구조화

### 리포지토리 인터페이스 확장
- **MenuJpaRepository**: `findByDateBetween` 메서드 추가
- **FoodMenuJpaRepository**: `findByMenu` 메서드 추가
- **FeedBackJpaRepository**: `findByFoodMenu` 메서드 추가
- **EvaluationJpaRepository**: `findByMenu` 메서드 추가
=> 위 부분만 추가 수정함

### 설정
- **RestTemplateConfig**: Django 서버와의 HTTP 통신을 위한 RestTemplate 설정
=> 기존 clientConfig가 있었으나,, 장고 쪽으로 데이터를 넘겨주기위한 직렬화, 포맷 등 데이터 정제 작업이 필요하여 새로 생성함

## 주요 기능

### 1. 특정 기간 데이터 수집 및 가공
- 날짜 범위 내의 모든 메뉴 데이터 조회
- 메뉴 평가 데이터 수집 및 번호 형식으로 가공
- 개별 음식 피드백 데이터 수집
- 평균 칼로리 계산
- 평균 평점 계산
- 제공된 모든 음식 목록 생성

### 2. 데이터 제한 처리
- 메뉴 평가 데이터가 100개 초과 시 랜덤 추출하여 제한
- 피드백 데이터가 100개 초과 시 랜덤 추출하여 제한

### 3. 예외 처리
- 해당 기간 데이터 없을 경우 적절한 오류 메시지 반환
- API 통신 오류 처리
- 데이터 가공 중 발생할 수 있는 예외 처리

### 4. Django 서버 통신
- 수집된 데이터 JSON 형식으로 변환
- HTTP POST 요청으로 Django 서버에 전송
- 서버로부터 생성된 마크다운 보고서 수신

## 사용 예시
```
POST /api/team3/aireport/generate
{
  "start_date": "2022-02-12",
  "end_date": "2022-04-12"
}
```
=> 위 요청된 기간 동안의 데이터로만 보고서가 생성됨

## 기타 특이사항
- 대용량 데이터 처리를 위한 최적화 로직 추가
- 기간 데이터를 Django로 전송하여 보고서 제목에 활용
- 보고서는 마크다운 형식으로 제공되어 추후 프론트엔드에서 렌더링 가능
=> .md 바로 pdf론 어려울듯? .md > html > pdf 이 순서로 변환 진행후 다운로드 할 수 있도록 api구조화 해야할듯.

## 테스트 진행 상황
- [x] 컨트롤러 요청/응답 테스트
- [x] Django 서버 연동 테스트
- [x] 예외 처리 테스트
- [x] 대용량 데이터 제한 테스트
=> 테스트 모두 완 & 보고서 정상 생성되는 것 확인함.
