### PR TITLE
[Feat] 챗봇 기능 구현을 위한 Spring Boot 서비스 개발 및 개선 작업

### DIFF
--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/controller/AiChatbotController.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/controller/AiChatbotController.java
@@ -1,0 +1,30 @@
+package com.example.SchoolLunchReport.aichatbot.controller;
+import com.example.SchoolLunchReport.aichatbot.dto.ChatbotRequestDto;
+import com.example.SchoolLunchReport.aichatbot.dto.ChatbotResponseDto;
+import com.example.SchoolLunchReport.aichatbot.service.AiChatbotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/team3/analytics/chatbot")
+public class AiChatbotController {
+    private final AiChatbotService aiChatbotService;
+    @PostMapping("/basic-chatbot-request")
+    public ResponseEntity<?> basicChatbotRequest(@RequestBody ChatbotRequestDto requestDto) {
+        ChatbotResponseDto responseDto = aiChatbotService.forwardToDjango(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+    @GetMapping("/food-info")
+    public ResponseEntity<List<String>> getFoodInfo() {
+        List<String> processedFoodData = aiChatbotService.getProcessedFoodData();
+        return ResponseEntity.ok(processedFoodData);
+    }
+    @GetMapping("/feedback-info")
+    public ResponseEntity<List<String>> getFeedbackInfo() {
+        List<String> processedFeedbackData = aiChatbotService.getProcessedFeedbackData();
+        return ResponseEntity.ok(processedFeedbackData);
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/ChatbotRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/ChatbotRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.SchoolLunchReport.aichatbot.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatbotRequestDto {
+    private String category;
+    private String question;
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/ChatbotResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/ChatbotResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.SchoolLunchReport.aichatbot.dto;
+
+import lombok.Data;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class ChatbotResponseDto {
+    private String message;
+    private String answer;
+    private List<Map<String, Object>> relevant_documents;
+}

--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/FeedbackInfoDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/FeedbackInfoDto.java
@@ -1,0 +1,45 @@
+package com.example.SchoolLunchReport.aichatbot.dto;
+
+import com.example.SchoolLunchReport.product.food.domain.entity.Food;
+import com.example.SchoolLunchReport.statistics.domain.feedback.entity.FeedBack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackInfoDto {
+    private Long id;
+    private String foodName;
+    private Double score;
+    private String evaluation;
+    private String processedContent;
+    private String createdDate;
+
+    public static FeedbackInfoDto fromEntity(FeedBack feedback) {
+        Food food = feedback.getFood();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        return FeedbackInfoDto.builder()
+                .id(feedback.getId())
+                .foodName(food.getName())
+                .score(feedback.getScore())
+                .evaluation(feedback.getEvaluation())
+                .createdDate(feedback.getCreatedAt().format(formatter))
+                .processedContent(generateProcessedContent(feedback, food))
+                .build();
+    }
+
+    private static String generateProcessedContent(FeedBack feedback, Food food) {
+        return String.format("%s 음식은 5점 만점 중 %.1f점을 받았으며, '%s'라는 평가를 받았습니다. 이 평가는 %s에 작성되었습니다.",
+                food.getName(),
+                feedback.getScore(),
+                feedback.getEvaluation(),
+                feedback.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")));
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/FoodInfoDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/dto/FoodInfoDto.java
@@ -1,0 +1,41 @@
+package com.example.SchoolLunchReport.aichatbot.dto;
+import com.example.SchoolLunchReport.product.food.domain.entity.Food;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FoodInfoDto {
+    private Long id;
+    private String name;
+    private String category;
+    private String nutrition;
+    private Double calorie;
+    private String allergy;
+    private String processedContent;
+
+    public static FoodInfoDto fromEntity(Food food) {
+        return FoodInfoDto.builder()
+                .id(food.getId())
+                .name(food.getName())
+                .category(food.getCategory().toString())
+                .nutrition(food.getNutrition())
+                .calorie(food.getCalorie())
+                .allergy(food.getAllergy())
+                .processedContent(generateProcessedContent(food))
+                .build();
+    }
+
+    private static String generateProcessedContent(Food food) {
+        return String.format("%s 음식의 영양소는 %s이며, 칼로리는 %.2f kcal입니다. 알러지 정보는 %s입니다. 카테고리는 %s입니다.",
+                food.getName(),
+                food.getNutrition(),
+                food.getCalorie(),
+                food.getAllergy(),
+                food.getCategory().toString());
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/aichatbot/service/AiChatbotService.java
+++ b/src/main/java/com/example/SchoolLunchReport/aichatbot/service/AiChatbotService.java
@@ -1,0 +1,108 @@
+package com.example.SchoolLunchReport.aichatbot.service;
+import com.example.SchoolLunchReport.aichatbot.dto.ChatbotRequestDto;
+import com.example.SchoolLunchReport.aichatbot.dto.ChatbotResponseDto;
+import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
+import com.example.SchoolLunchReport.product.FoodMenu.repository.FoodMenuJpaRepository;
+import com.example.SchoolLunchReport.product.evaluation.repository.EvaluationJpaRepository;
+import com.example.SchoolLunchReport.product.food.domain.entity.Food;
+import com.example.SchoolLunchReport.product.food.repository.FoodJpaRepository;
+import com.example.SchoolLunchReport.product.menu.repository.MenuJpaRepository;
+import com.example.SchoolLunchReport.statistics.domain.feedback.entity.FeedBack;
+import com.example.SchoolLunchReport.statistics.domain.feedback.repo.FeedBackJpaRepo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiChatbotService {
+    private final MenuJpaRepository menuJpaRepository;
+    private final EvaluationJpaRepository evaluationJpaRepository;
+    private final FoodMenuJpaRepository foodMenuJpaRepository;
+    private final FeedBackJpaRepo feedBackJpaRepository;
+    private final FoodJpaRepository foodJpaRepository;
+
+    @Qualifier("chatbotRestTemplate")
+    private final RestTemplate chatbotRestTemplate;
+    // private static final String DJANGO_BASE_URL = "http://127.0.0.1:8000/api/team3/llmchatbot/basic_chatbot_request/";
+    private static final String DJANGO_BASE_URL = "http://k8s-msaservices-7d023f0bb9-676035063.ap-northeast-2.elb.amazonaws.com/api/team3/llmchatbot/basic_chatbot_request/";
+
+    public ChatbotResponseDto forwardToDjango(ChatbotRequestDto requestDto) {
+        try {
+            log.info("Forwarding request to Django - Category: {}, Question: {}",
+                    requestDto.getCategory(), requestDto.getQuestion());
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<ChatbotRequestDto> request = new HttpEntity<>(requestDto, headers);
+
+            ChatbotResponseDto response = chatbotRestTemplate.postForObject(
+                    DJANGO_BASE_URL, request, ChatbotResponseDto.class);
+
+            return response;
+        } catch (Exception e) {
+            log.error("Error forwarding request to Django: {}", e.getMessage());
+
+            ChatbotResponseDto errorResponse = new ChatbotResponseDto();
+            errorResponse.setMessage("Django 서비스와 통신 중 오류가 발생했습니다");
+            errorResponse.setAnswer(null);
+
+            return errorResponse;
+        }
+    }
+
+    public List<String> getProcessedFoodData() {
+        List<Food> allFoods = foodJpaRepository.findAll();
+        log.info("Retrieved {} food items", allFoods.size());
+
+        return allFoods.stream()
+                .map(this::processFood)
+                .collect(Collectors.toList());
+    }
+
+    private String processFood(Food food) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(food.getName())
+                .append("의 영양소는 ")
+                .append(food.getNutrition())
+                .append("이며, 칼로리는 ")
+                .append(food.getCalorie())
+                .append("kcal이고, 알러지 정보는 ")
+                .append(food.getAllergy())
+                .append("입니다.");
+
+        return sb.toString();
+    }
+
+    public List<String> getProcessedFeedbackData() {
+        List<FeedBack> allFeedbacks = feedBackJpaRepository.findAll();
+        log.info("Retrieved {} feedback items", allFeedbacks.size());
+        List<String> processedData = new ArrayList<>();
+        for (FeedBack feedback : allFeedbacks) {
+            try {
+                FoodMenu foodMenu = feedback.getFoodMenu();
+                Food food = foodMenu.getFood();
+
+                String processedFeedback = String.format(
+                        "%s는 5점 만점 중 %.1f점을 받았으며, \"%s\"라는 평가를 받았습니다.",
+                        food.getName(),
+                        feedback.getScore(),
+                        feedback.getEvaluation()
+                );
+                processedData.add(processedFeedback);
+            } catch (Exception e) {
+                log.error("Error processing feedback item: {}", e.getMessage());
+            }
+        }
+        return processedData;
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/service/DatasetService.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/service/DatasetService.java
@@ -109,17 +109,13 @@ public class DatasetService {
                 throw new IllegalArgumentException("점수는 1~5 사이의 값이어야 합니다: " + dto.getScore());
             }
             FoodMenu foodMenu = foodMenuJpaRepository.findById(dto.getFoodMenuId())
-                .orElseThrow(() -> new IllegalArgumentException(
-                    "ID가 " + dto.getFoodMenuId() + "인 푸드메뉴를 찾을 수 없습니다"));
-            if (feedBackJpaRepo.existsByFoodMenuId(dto.getFoodMenuId())) {
-                continue;
-            }
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "ID가 " + dto.getFoodMenuId() + "인 푸드메뉴를 찾을 수 없습니다"));
             FeedBack feedBack = FeedBack.builder()
-                .score(dto.getScore())
-                .foodMenu(foodMenu)
-                .evaluation(dto.getEvaluation())
-                .build();
-            setField(feedBack, "foodMenu", foodMenu);
+                    .score(dto.getScore())
+                    .foodMenu(foodMenu)
+                    .evaluation(dto.getEvaluation())
+                    .build();
             feedBackList.add(feedBack);
         }
         feedBackJpaRepo.saveAll(feedBackList);
@@ -139,7 +135,6 @@ public class DatasetService {
             FeedBack feedBack = FeedBack.builder()
                 .score(randomScore)
                 .foodMenu(foodMenu)
-                .createdAt(registerDate)
                 .build();
             feedBackList.add(feedBack);
         }

--- a/src/main/java/com/example/SchoolLunchReport/global/config/AiChatbotRestTemplateConfig.java
+++ b/src/main/java/com/example/SchoolLunchReport/global/config/AiChatbotRestTemplateConfig.java
@@ -1,0 +1,45 @@
+package com.example.SchoolLunchReport.global.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+@Configuration
+public class AiChatbotRestTemplateConfig {
+    @Bean(name = "chatbotRestTemplate")
+    public RestTemplate chatbotRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(50000);
+        factory.setReadTimeout(50000);
+
+        RestTemplate restTemplate = new RestTemplate(factory);
+
+        MappingJackson2HttpMessageConverter jsonConverter = new MappingJackson2HttpMessageConverter();
+        jsonConverter.setSupportedMediaTypes(
+                Arrays.asList(
+                        MediaType.APPLICATION_JSON,
+                        MediaType.APPLICATION_JSON_UTF8
+                )
+        );
+
+        StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
+        stringConverter.setWriteAcceptCharset(false);
+
+        restTemplate.setMessageConverters(Arrays.asList(jsonConverter, stringConverter));
+
+        restTemplate.setInterceptors(Collections.singletonList((request, body, execution) -> {
+            System.out.println("요청 URL: " + request.getURI());
+            System.out.println("요청 방식: " + request.getMethod());
+            System.out.println("요청 본문: " + new String(body, StandardCharsets.UTF_8));
+            return execution.execute(request, body);
+        }));
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/feedback/entity/FeedBack.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/feedback/entity/FeedBack.java
@@ -26,10 +26,9 @@ public class FeedBack extends BaseTimeEntity {
     private FoodMenu foodMenu;
     private String evaluation;
     @Builder
-    public FeedBack(Double score, FoodMenu foodMenu, String evaluation, LocalDate createdAt) {
+    public FeedBack(Double score, FoodMenu foodMenu, String evaluation) {
         this.score = score;
         this.foodMenu = foodMenu;
-        this.createdAt = createdAt;
         this.evaluation = evaluation;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: team03-be
 
   datasource:
-    url: jdbc:mysql://msa-service-team03-eks.c3kygsge2own.ap-northeast-2.rds.amazonaws.com:3306/paper1?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-    username: admin
-    password: msa_service
+    url: jdbc:mysql://paper-data-crawling.cl64kkugmebl.ap-northeast-2.rds.amazonaws.com:3306/paper1?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+    username: paper
+    password: paper)paper123
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
## Spring Boot 개발 PR 설명
### 개요
학교 급식 시스템의 챗봇 기능 구현을 위한 Spring Boot 서비스 개발 및 개선 작업을 진행함. 
Spring Boot 서버는 클라이언트 요청을 받아 Django 서버로 전달하고, 최종적으로 사용자에게 llm을 통해 응답을 반환하는 역할

### 주요 개발 내용
1. RestTemplate 통신 구조 개선
- 기존 RestTemplate 주입 방식을 개선하여 안정적인 통신 구조 구축
- @Qualifier 어노테이션을 활용한 명확한 빈 주입 구현
- HTTP 요청 구성 방식 개선으로 JSON 직렬화 문제 해결
- 커스텀 HTTP 메시지 컨버터 설정으로 한글 및 특수문자 처리 최적화

2. ChatbotRequestDto & ChatbotResponseDto 개선
- ChatbotRequestDto 클래스 보완
- ChatbotResponseDto 클래스에 LLM 응답 필드 추가 (answer, relevant_documents)
- 불필요한 data 필드 제거로 응답 구조 최적화
- 객체 직렬화/역직렬화

3. 예외 처리 및 로깅 시스템 강화
- 다양한 통신 예외 상황에 대한 견고한 예외 처리 로직 구현
- 요청/응답 전체 과정에 대한 상세 로그 시스템 구축
- Django 서버 연결 실패 시 대체 응답 생성 메커니즘 구현

4. 서비스 레이어 최적화
- AiChatbotService 클래스의 메서드 구조 개선 및 책임 명확화
- 음식 정보 및 피드백 정보 처리 로직 모듈화
- 코드 중복 제거 및 가독성 개선

[구조]
Spring Boot의 컨트롤러-서비스-리포지토리 패턴을 활용한 구조적 설계
RestTemplate 대신 WebClient 사용을 고려했으나, 현재 시스템과의 호환성을 위해 RestTemplate 유지함

## 개발 내용 요약
### 클래스 및 메서드
- ChatbotRequestDto: 장고 서버로 전송할 요청 객체
category: 요청 카테고리 (FOOD_INFO, FOOD_FEEDBACK_INFO)
question: 사용자 질문

- ChatbotResponseDto: 장고 서버로부터 받는 응답 객체
message: 성공/실패 메시지
answer: OpenAI 생성 응답
relevant_documents: 유사도 검색 결과 문서 리스트

- AiChatbotService: 챗봇 서비스 클래스
forwardToDjango(): 장고 서버로 요청 전달 메서드

- AiChatbotRestTemplateConfig: RestTemplate 설정 클래스
chatbotRestTemplate(): 커스텀 RestTemplate 설정 빈