### PR TITLE
[Feat] 특정 기간동안 나온 음식의 카테고리별 등장 횟수 조회 API 구현

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/avro-schemas"]
+	path = src/main/avro-schemas
+	url = https://github.com/0702Yoon/avro.git

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.github.davidmc24.gradle.plugin.avro' version '1.5.0'
 }
 
 group = 'com.example'
@@ -21,6 +22,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://packages.confluent.io/maven/' }
 }
 
 dependencies {
@@ -31,6 +33,7 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation "io.swagger.core.v3:swagger-annotations:2.2.15"
 
     // db
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -41,8 +44,14 @@ dependencies {
 
     // monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     //kafka
-//    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    //avro
+    implementation 'org.apache.avro:avro:1.11.4'
+    implementation 'io.confluent:kafka-avro-serializer:7.6.0'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
@@ -71,9 +80,14 @@ tasks.withType(JavaCompile).configureEach {
     options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
+avro {
+    fieldVisibility = "PRIVATE"
+}
+
 clean {
     delete file(querydslDir)
 }
 tasks.named('test') {
     useJUnitPlatform()
 }
+

--- a/src/main/generated/com/example/SchoolLunchReport/product/food/domain/entity/QFood.java
+++ b/src/main/generated/com/example/SchoolLunchReport/product/food/domain/entity/QFood.java
@@ -31,6 +31,8 @@ public class QFood extends EntityPathBase<Food> {
 
     public final StringPath nutrition = createString("nutrition");
 
+    public final EnumPath<com.example.SchoolLunchReport.product.food.domain.type.SubCategory> subCategory = createEnum("subCategory", com.example.SchoolLunchReport.product.food.domain.type.SubCategory.class);
+
     public QFood(String variable) {
         super(Food.class, forVariable(variable));
     }

--- a/src/main/java/com/example/SchoolLunchReport/product/food/domain/entity/Food.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/domain/entity/Food.java
@@ -1,23 +1,33 @@
 package com.example.SchoolLunchReport.product.food.domain.entity;
+
 import com.example.SchoolLunchReport.product.food.domain.type.Category;
+import com.example.SchoolLunchReport.product.food.domain.type.SubCategory;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 @Entity
 @Getter
 @NoArgsConstructor
 public class Food {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
+    @Enumerated(value = EnumType.STRING)
     private Category category;
+
+    @Enumerated(value = EnumType.STRING)
+    private SubCategory subCategory;
 
     private String nutrition;
 
@@ -27,11 +37,12 @@ public class Food {
 
     @Builder
     public Food(String name, Category category, String nutrition, Double calorie,
-        String allergy) {
+        String allergy, SubCategory subCategory) {
         this.name = name;
         this.category = category;
         this.nutrition = nutrition;
         this.calorie = calorie;
         this.allergy = allergy;
+        this.subCategory = subCategory;
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/product/food/domain/type/Category.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/domain/type/Category.java
@@ -1,7 +1,10 @@
 package com.example.SchoolLunchReport.product.food.domain.type;
+
 import java.util.Arrays;
+
 public enum Category {
     RICE, SOUP, MAIN_DISH, SIDE_DISH, DESSERT;
+
     public static Category getInstance(String name) {
         return Arrays.stream(values())
             .filter(type -> type.name().equals(name))

--- a/src/main/java/com/example/SchoolLunchReport/product/food/domain/type/SubCategory.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/domain/type/SubCategory.java
@@ -1,0 +1,46 @@
+package com.example.SchoolLunchReport.product.food.domain.type;
+
+public enum SubCategory {
+    //Rice 하위
+    WHITE_RICE(Category.RICE), //흰쌀밥
+    MIXED_GRAIN_RICE(Category.RICE), //잡곡밥
+    FRIED_RICE(Category.RICE), //볶음
+    SPECIAL_RICE(Category.RICE), //김밥, 주먹밥, 비빔밥 등
+    // MAIN_DISH 하위
+    MEAT(Category.MAIN_DISH), // 제육볶음, 불고기, 돈까스 등
+    POULTRY(Category.MAIN_DISH), // 가금류:  닭갈비, 닭튀김 등
+    FISH(Category.MAIN_DISH), // (생선류): 고등어조림, 생선구이 등
+    FRIED(Category.MAIN_DISH), //  (튀김류): 치킨가라아게, 탕수육, 돈까스 등
+    STEAMED_OR_BOILED(Category.MAIN_DISH), // (찜/조림류): 갈비찜, 코다리조림 등
+    VEGETARIAN_MAIN(Category.MAIN_DISH), // (채식 메인): 두부스테이크, 야채볶음 등
+
+    // SIDE_DISH 하위
+    KIMCHI_VARIANT(Category.SIDE_DISH), //(김치류): 배추김치, 총각김치 등
+    NAMUL(Category.SIDE_DISH),// (나물류): 시금치나물, 고사리 등
+    PICKLED(Category.SIDE_DISH), // (장아찌류): 오이지, 깍두기 등
+    EGG_BASED(Category.SIDE_DISH), // (계란류): 계란말이, 계란찜 등
+    TOFU_OR_BEAN(Category.SIDE_DISH), // (두부/콩류): 두부조림, 콩자반 등
+    SMALL_MEAT(Category.SIDE_DISH), // (소량 육류 반찬): 소고기장조림, 소세지볶음 등
+
+    // SOUP 하위
+    CLEAR_SOUP(Category.SOUP), //    맑은국: 미역국, 북어국 등
+    SPICY_SOUP(Category.SOUP), //    얼큰한 국/찌개): 김치찌개, 육개장 등
+    STEW(Category.SOUP), //    찌개류): 된장찌개, 순두부찌개
+    MEAT_SOUP(Category.SOUP), //   (육류탕): 설렁탕, 갈비탕
+    FISH_SOUP(Category.SOUP), //    어류탕): 대구탕, 매운탕
+    // 디저트
+    FRUIT(Category.DESSERT), //    (과일류): 바나나, 사과 등
+    DAIRY(Category.DESSERT), //    (유제품): 요구르트, 푸딩
+    BAKED(Category.DESSERT), //    (빵/케이크): 단팥빵, 카스테라
+    SNACK(Category.DESSERT), // 완전 간식
+    BEVERAGE(Category.DESSERT);//    음료): 쥬스, 식혜 등
+    private final Category parentCategory;
+
+    SubCategory(Category parentCategory) {
+        this.parentCategory = parentCategory;
+    }
+
+    public Category getParentCategory() {
+        return parentCategory;
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/food/domain/vo/DesiredFoodVo.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/domain/vo/DesiredFoodVo.java
@@ -1,7 +1,7 @@
 package com.example.SchoolLunchReport.product.food.domain.vo;
 
 public record DesiredFoodVo(
-
+//TODO 삭제
 ) {
 
 }

--- a/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodJpaRepository.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodJpaRepository.java
@@ -1,10 +1,13 @@
 package com.example.SchoolLunchReport.product.food.repository;
+
 import com.example.SchoolLunchReport.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.product.food.domain.type.Category;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import java.util.List;
+
 @Repository
-public interface FoodJpaRepository extends JpaRepository<Food, Long> {
+public interface FoodJpaRepository extends JpaRepository<Food, Long>, FoodRepositoryCustom {
+
     List<Food> findByCategory(Category category);
 }

--- a/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodJpaRepositoryImpl.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodJpaRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.example.SchoolLunchReport.product.food.repository;
+
+import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.QFoodMenu;
+import com.example.SchoolLunchReport.product.food.domain.entity.QFood;
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FoodJpaRepositoryImpl implements FoodRepositoryCustom {
+
+    final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<FoodFrequencyDto> countByCategoryBetween(LocalDate startDate,
+        LocalDate endDate) {
+
+        QFoodMenu fm = QFoodMenu.foodMenu;
+        QFood food = QFood.food;
+        return queryFactory
+            .select(Projections.constructor(
+                FoodFrequencyDto.class,
+                food.category,
+                food.subCategory,
+                food.subCategory.count()
+            ))
+            .from(fm)
+            .join(fm.food, food)
+            .where(fm.menu.date.between(startDate, endDate))
+            .groupBy(food.subCategory)
+            .fetch();
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodRepositoryCustom.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/repository/FoodRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.SchoolLunchReport.product.food.repository;
+
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface FoodRepositoryCustom {
+
+    List<FoodFrequencyDto> countByCategoryBetween(LocalDate startDate,
+        LocalDate endDate);
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/food/repository/dto/FoodFrequencyDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/repository/dto/FoodFrequencyDto.java
@@ -1,0 +1,12 @@
+package com.example.SchoolLunchReport.product.food.repository.dto;
+
+import com.example.SchoolLunchReport.product.food.domain.type.Category;
+import com.example.SchoolLunchReport.product.food.domain.type.SubCategory;
+
+public record FoodFrequencyDto(
+    Category category,
+    SubCategory subCategory,
+    Long count
+) {
+
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/food/service/FoodService.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/service/FoodService.java
@@ -1,0 +1,24 @@
+package com.example.SchoolLunchReport.product.food.service;
+
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import com.example.SchoolLunchReport.product.food.support.FoodReader;
+import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FoodService {
+
+    final FoodReader foodReader;
+
+    public List<FoodFrequencyDto> getFoodFrequencyByCategory(
+        Boundary boundary) {
+        return foodReader.getFoodFrequencyInBoundary(boundary).stream()
+            .sorted(Comparator.comparing(FoodFrequencyDto::category))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/food/support/FoodReader.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/food/support/FoodReader.java
@@ -1,0 +1,20 @@
+package com.example.SchoolLunchReport.product.food.support;
+
+import com.example.SchoolLunchReport.product.food.repository.FoodJpaRepository;
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FoodReader {
+
+    final FoodJpaRepository foodJpaRepository;
+
+    public List<FoodFrequencyDto> getFoodFrequencyInBoundary(Boundary boundary) {
+        return foodJpaRepository.countByCategoryBetween(
+            boundary.startDate(), boundary.endDate());
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/product/menu/domain/entity/Menu.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/menu/domain/entity/Menu.java
@@ -1,15 +1,25 @@
 package com.example.SchoolLunchReport.product.menu.domain.entity;
-import com.example.SchoolLunchReport.product.menu.domain.type.MealType;
-import jakarta.persistence.*;
 
+import com.example.SchoolLunchReport.product.menu.domain.type.MealType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.time.LocalDate;
 import lombok.Getter;
+
 @Entity
 @Getter
 public class Menu {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    
     private LocalDate date;
+
+    @Enumerated(value = EnumType.STRING)
     private MealType mealType;
 }

--- a/src/main/java/com/example/SchoolLunchReport/product/menu/service/MenuService.java
+++ b/src/main/java/com/example/SchoolLunchReport/product/menu/service/MenuService.java
@@ -1,7 +1,6 @@
 package com.example.SchoolLunchReport.product.menu.service;
 
 import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
-import com.example.SchoolLunchReport.product.menu.repository.MenuJpaRepository;
 import com.example.SchoolLunchReport.product.menu.support.MenuReader;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import java.util.List;
@@ -12,12 +11,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MenuService {
 
-    final MenuJpaRepository menuJpaRepository;
     final MenuReader menuReader;
 
     public List<Menu> getMenuInBoundary(Boundary boundary) {
         return menuReader.getMenuInBoundary(boundary);
     }
-
-
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
@@ -4,7 +4,8 @@ import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TE
 
 import com.example.SchoolLunchReport.global.response.ApiResponse;
 import com.example.SchoolLunchReport.global.response.type.SuccessType;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedRankMenuResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.RankMenuResponseDto;
@@ -79,10 +80,10 @@ public class StatisticsController implements StatisticsControllerDocs {
 
     @GetMapping("/desired-food/{periodType}")
     public ApiResponse<List<DesiredFoodResponseDto>> getDesiredFood(
-        @Valid @ModelAttribute DesiredFoodRequestDto desiredFoodRequestDto
+        @Valid @ModelAttribute PeriodSpecDto periodSpecDto
     ) {
         List<DesiredFoodResponseDto> desiredFoodResponseDto = statisticsFacade.getDesiredFood(
-            desiredFoodRequestDto);
+            periodSpecDto);
         return ApiResponse.success(SuccessType.SUCCESS, desiredFoodResponseDto);
     }
 
@@ -97,4 +98,13 @@ public class StatisticsController implements StatisticsControllerDocs {
         return ApiResponse.success(SuccessType.SUCCESS, categoryScore);
     }
 
+    @Override
+    @GetMapping("/food/frequency")
+    public ApiResponse<?> getMenuFrequencyByCategory(
+        @Valid @ModelAttribute PeriodSpecDto periodSpecDto
+    ) {
+        List<FoodFrequencyDto> menuFrequencyByCategory = statisticsFacade.getMenuFrequencyByCategory(
+            periodSpecDto);
+        return ApiResponse.success(SuccessType.SUCCESS, menuFrequencyByCategory);
+    }
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsController.java
@@ -5,7 +5,7 @@ import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TE
 import com.example.SchoolLunchReport.global.response.ApiResponse;
 import com.example.SchoolLunchReport.global.response.type.SuccessType;
 import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedRankMenuResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.RankMenuResponseDto;
@@ -80,10 +80,10 @@ public class StatisticsController implements StatisticsControllerDocs {
 
     @GetMapping("/desired-food/{periodType}")
     public ApiResponse<List<DesiredFoodResponseDto>> getDesiredFood(
-        @Valid @ModelAttribute PeriodSpecDto periodSpecDto
+        @Valid @ModelAttribute PeriodSpecRequestDto periodSpecRequestDto
     ) {
         List<DesiredFoodResponseDto> desiredFoodResponseDto = statisticsFacade.getDesiredFood(
-            periodSpecDto);
+            periodSpecRequestDto);
         return ApiResponse.success(SuccessType.SUCCESS, desiredFoodResponseDto);
     }
 
@@ -101,10 +101,10 @@ public class StatisticsController implements StatisticsControllerDocs {
     @Override
     @GetMapping("/food/frequency")
     public ApiResponse<?> getMenuFrequencyByCategory(
-        @Valid @ModelAttribute PeriodSpecDto periodSpecDto
+        @Valid @ModelAttribute PeriodSpecRequestDto periodSpecRequestDto
     ) {
         List<FoodFrequencyDto> menuFrequencyByCategory = statisticsFacade.getMenuFrequencyByCategory(
-            periodSpecDto);
+            periodSpecRequestDto);
         return ApiResponse.success(SuccessType.SUCCESS, menuFrequencyByCategory);
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsControllerDocs.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsControllerDocs.java
@@ -1,7 +1,7 @@
 package com.example.SchoolLunchReport.statistics.controller;
 
 import com.example.SchoolLunchReport.global.response.ApiResponse;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.TrackingResponseDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
@@ -31,8 +31,13 @@ public interface StatisticsControllerDocs {
 
     @Operation(summary = "먹고 싶은 메뉴 조회")
     ApiResponse<List<DesiredFoodResponseDto>> getDesiredFood(
-        DesiredFoodRequestDto desiredFoodRequestDto);
+        PeriodSpecDto periodSpecDto);
 
     @Operation(summary = "카테고리별 평점 조회 API")
     ApiResponse<?> getCategoryScore(LocalDate startDate, LocalDate endDate);
+
+    @Operation(summary = "카테고리별 빈도 통계 조회 API")
+    ApiResponse<?> getMenuFrequencyByCategory(
+        PeriodSpecDto periodSpecDto
+    );
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsControllerDocs.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/StatisticsControllerDocs.java
@@ -1,7 +1,7 @@
 package com.example.SchoolLunchReport.statistics.controller;
 
 import com.example.SchoolLunchReport.global.response.ApiResponse;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.TrackingResponseDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
@@ -31,13 +31,13 @@ public interface StatisticsControllerDocs {
 
     @Operation(summary = "먹고 싶은 메뉴 조회")
     ApiResponse<List<DesiredFoodResponseDto>> getDesiredFood(
-        PeriodSpecDto periodSpecDto);
+        PeriodSpecRequestDto periodSpecRequestDto);
 
     @Operation(summary = "카테고리별 평점 조회 API")
     ApiResponse<?> getCategoryScore(LocalDate startDate, LocalDate endDate);
 
     @Operation(summary = "카테고리별 빈도 통계 조회 API")
     ApiResponse<?> getMenuFrequencyByCategory(
-        PeriodSpecDto periodSpecDto
+        PeriodSpecRequestDto periodSpecRequestDto
     );
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/dto/request/PeriodSpecDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/dto/request/PeriodSpecDto.java
@@ -1,6 +1,5 @@
 package com.example.SchoolLunchReport.statistics.controller.dto.request;
 
-
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.Semester;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,7 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.Month;
 
-public record DesiredFoodRequestDto(
+public record PeriodSpecDto(
     @NotNull
     @Schema(description = "타입", example = "MONTHLY, SEMESTER")
     PeriodType periodType,
@@ -32,5 +31,5 @@ public record DesiredFoodRequestDto(
             return semester != null;
         }
     }
-}
 
+}

--- a/src/main/java/com/example/SchoolLunchReport/statistics/controller/dto/request/PeriodSpecRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/controller/dto/request/PeriodSpecRequestDto.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.Month;
 
-public record PeriodSpecDto(
+public record PeriodSpecRequestDto(
     @NotNull
     @Schema(description = "타입", example = "MONTHLY, SEMESTER")
     PeriodType periodType,

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/entity/Boundary.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/entity/Boundary.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record Boundary(
+    //TODO 패키지명 변경
     LocalDate startDate,
     LocalDate endDate
 ) {

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/BoundaryMapper.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/BoundaryMapper.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator.BoundaryCalculator;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
@@ -26,10 +26,10 @@ public class BoundaryMapper {
         }
     }
 
-    public Boundary mapBoundary(DesiredFoodRequestDto desiredFoodRequestDto) {
-        PeriodType periodType = desiredFoodRequestDto.periodType();
+    public Boundary mapBoundary(PeriodSpecDto periodSpecDto) {
+        PeriodType periodType = periodSpecDto.periodType();
         BoundaryCalculator boundaryCalculator = calculatorMap.get(periodType);
-        return boundaryCalculator.getBoundary(desiredFoodRequestDto);
+        return boundaryCalculator.getBoundary(periodSpecDto);
     }
 
     public Boundary mapBoundary(PeriodType periodType, LocalDate conditionDate) {

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/BoundaryMapper.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/BoundaryMapper.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator.BoundaryCalculator;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
@@ -26,10 +26,10 @@ public class BoundaryMapper {
         }
     }
 
-    public Boundary mapBoundary(PeriodSpecDto periodSpecDto) {
-        PeriodType periodType = periodSpecDto.periodType();
+    public Boundary mapBoundary(PeriodSpecRequestDto periodSpecRequestDto) {
+        PeriodType periodType = periodSpecRequestDto.periodType();
         BoundaryCalculator boundaryCalculator = calculatorMap.get(periodType);
-        return boundaryCalculator.getBoundary(periodSpecDto);
+        return boundaryCalculator.getBoundary(periodSpecRequestDto);
     }
 
     public Boundary mapBoundary(PeriodType periodType, LocalDate conditionDate) {

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/BoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/BoundaryCalculator.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.LocalDate;
@@ -16,5 +16,5 @@ public interface BoundaryCalculator {
 
     LocalDate getStartOfPreviousPeriod(LocalDate date);
 
-    Boundary getBoundary(PeriodSpecDto periodSpecDto);
+    Boundary getBoundary(PeriodSpecRequestDto periodSpecRequestDto);
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/BoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/BoundaryCalculator.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.LocalDate;
@@ -16,5 +16,5 @@ public interface BoundaryCalculator {
 
     LocalDate getStartOfPreviousPeriod(LocalDate date);
 
-    Boundary getBoundary(DesiredFoodRequestDto desiredFoodRequestDto);
+    Boundary getBoundary(PeriodSpecDto periodSpecDto);
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/MonthlyBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/MonthlyBoundaryCalculator.java
@@ -2,7 +2,7 @@ package com.example.SchoolLunchReport.statistics.domain.boundary.support.calcula
 
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.MONTHLY;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.LocalDate;
@@ -43,9 +43,9 @@ public class MonthlyBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(DesiredFoodRequestDto desiredFoodRequestDto) {
-        Integer year = desiredFoodRequestDto.year();
-        int month = desiredFoodRequestDto.month().getValue();
+    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
+        Integer year = periodSpecDto.year();
+        int month = periodSpecDto.month().getValue();
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = LocalDate.of(year, month, startDate.lengthOfMonth());
         return new Boundary(startDate, endDate);

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/MonthlyBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/MonthlyBoundaryCalculator.java
@@ -2,7 +2,7 @@ package com.example.SchoolLunchReport.statistics.domain.boundary.support.calcula
 
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.MONTHLY;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.LocalDate;
@@ -43,9 +43,9 @@ public class MonthlyBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
-        Integer year = periodSpecDto.year();
-        int month = periodSpecDto.month().getValue();
+    public Boundary getBoundary(PeriodSpecRequestDto periodSpecRequestDto) {
+        Integer year = periodSpecRequestDto.year();
+        int month = periodSpecRequestDto.month().getValue();
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = LocalDate.of(year, month, startDate.lengthOfMonth());
         return new Boundary(startDate, endDate);

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/SemesterBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/SemesterBoundaryCalculator.java
@@ -2,7 +2,7 @@ package com.example.SchoolLunchReport.statistics.domain.boundary.support.calcula
 
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.SEMESTER;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.Semester;
@@ -34,9 +34,9 @@ public class SemesterBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(DesiredFoodRequestDto desiredFoodRequestDto) {
-        LocalDate startDate = getSemesterStartDate(desiredFoodRequestDto.year(),
-            desiredFoodRequestDto.semester());
+    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
+        LocalDate startDate = getSemesterStartDate(periodSpecDto.year(),
+            periodSpecDto.semester());
         LocalDate endDate = getSemesterEndDate(startDate);
         return new Boundary(startDate, endDate);
     }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/SemesterBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/SemesterBoundaryCalculator.java
@@ -2,7 +2,7 @@ package com.example.SchoolLunchReport.statistics.domain.boundary.support.calcula
 
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.SEMESTER;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.Semester;
@@ -34,9 +34,9 @@ public class SemesterBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
-        LocalDate startDate = getSemesterStartDate(periodSpecDto.year(),
-            periodSpecDto.semester());
+    public Boundary getBoundary(PeriodSpecRequestDto periodSpecRequestDto) {
+        LocalDate startDate = getSemesterStartDate(periodSpecRequestDto.year(),
+            periodSpecRequestDto.semester());
         LocalDate endDate = getSemesterEndDate(startDate);
         return new Boundary(startDate, endDate);
     }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/WeeklyBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/WeeklyBoundaryCalculator.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.DayOfWeek;
@@ -38,7 +38,7 @@ public class WeeklyBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
+    public Boundary getBoundary(PeriodSpecRequestDto periodSpecRequestDto) {
         return null;
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/WeeklyBoundaryCalculator.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/domain/boundary/support/calculator/WeeklyBoundaryCalculator.java
@@ -1,6 +1,6 @@
 package com.example.SchoolLunchReport.statistics.domain.boundary.support.calculator;
 
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.domain.boundary.entity.Boundary;
 import com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType;
 import java.time.DayOfWeek;
@@ -38,7 +38,7 @@ public class WeeklyBoundaryCalculator implements BoundaryCalculator {
     }
 
     @Override
-    public Boundary getBoundary(DesiredFoodRequestDto desiredFoodRequestDto) {
+    public Boundary getBoundary(PeriodSpecDto periodSpecDto) {
         return null;
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/service/StatisticsFacade.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/service/StatisticsFacade.java
@@ -7,7 +7,7 @@ import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDt
 import com.example.SchoolLunchReport.product.food.service.FoodService;
 import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
 import com.example.SchoolLunchReport.product.menu.service.MenuService;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecRequestDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedRankMenuResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedStatisticsResponse;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
@@ -99,9 +99,9 @@ public class StatisticsFacade {
 
     @Transactional(readOnly = true)
     public List<DesiredFoodResponseDto> getDesiredFood(
-        PeriodSpecDto periodSpecDto
+        PeriodSpecRequestDto periodSpecRequestDto
     ) {
-        Boundary boundary = boundaryMapper.mapBoundary(periodSpecDto);
+        Boundary boundary = boundaryMapper.mapBoundary(periodSpecRequestDto);
         return desiredFoodService.getDesiredFoodTopN(boundary, 3);
     }
 
@@ -110,8 +110,8 @@ public class StatisticsFacade {
     }
 
     public List<FoodFrequencyDto> getMenuFrequencyByCategory(
-        PeriodSpecDto periodSpecDto) {
-        Boundary boundary = boundaryMapper.mapBoundary(periodSpecDto);
+        PeriodSpecRequestDto periodSpecRequestDto) {
+        Boundary boundary = boundaryMapper.mapBoundary(periodSpecRequestDto);
         return foodService.getFoodFrequencyByCategory(boundary);
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/statistics/service/StatisticsFacade.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/service/StatisticsFacade.java
@@ -3,9 +3,11 @@ package com.example.SchoolLunchReport.statistics.service;
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.MONTHLY;
 import static com.example.SchoolLunchReport.statistics.domain.boundary.type.PeriodType.WEEKLY;
 
+import com.example.SchoolLunchReport.product.food.repository.dto.FoodFrequencyDto;
+import com.example.SchoolLunchReport.product.food.service.FoodService;
 import com.example.SchoolLunchReport.product.menu.domain.entity.Menu;
 import com.example.SchoolLunchReport.product.menu.service.MenuService;
-import com.example.SchoolLunchReport.statistics.controller.dto.request.DesiredFoodRequestDto;
+import com.example.SchoolLunchReport.statistics.controller.dto.request.PeriodSpecDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedRankMenuResponseDto;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.CombinedStatisticsResponse;
 import com.example.SchoolLunchReport.statistics.controller.dto.response.DesiredFoodResponseDto;
@@ -35,6 +37,7 @@ public class StatisticsFacade {
 
     final MenuService menuService;
     final FeedBackService feedBackService;
+    final FoodService foodService;
     final DesiredFoodService desiredFoodService;
     final RankService rankService;
     final BoundaryMapper boundaryMapper;
@@ -96,13 +99,19 @@ public class StatisticsFacade {
 
     @Transactional(readOnly = true)
     public List<DesiredFoodResponseDto> getDesiredFood(
-        DesiredFoodRequestDto desiredFoodRequestDto
+        PeriodSpecDto periodSpecDto
     ) {
-        Boundary boundary = boundaryMapper.mapBoundary(desiredFoodRequestDto);
+        Boundary boundary = boundaryMapper.mapBoundary(periodSpecDto);
         return desiredFoodService.getDesiredFoodTopN(boundary, 3);
     }
 
     public List<CategoryScoreAvgDto> getCategoryScore(LocalDate startDate, LocalDate endDate) {
         return feedBackService.getCategoryScore(startDate, endDate);
+    }
+
+    public List<FoodFrequencyDto> getMenuFrequencyByCategory(
+        PeriodSpecDto periodSpecDto) {
+        Boundary boundary = boundaryMapper.mapBoundary(periodSpecDto);
+        return foodService.getFoodFrequencyByCategory(boundary);
     }
 }


### PR DESCRIPTION
🌱 관련 이슈

close: #이슈번호
📌 작업 내용 및 특이사항

학기 또는 월 단위로 요청을 받아, 해당 기간 동안 급식에 등장한 음식의 출현 횟수를 조회하는 기능을 구현했습니다.
음식 항목에 **서브 카테고리(subcategory)**를 추가하고, 해당 카테고리 기준으로 등장 횟수를 그룹화하여 계산했습니다.
기존 요청/응답 객체였던 DesiredRequestDto, FoodFrequencyDto를 하나의 PeriodSpecRequestDto로 통합하여 구조를 단순화했습니다.
📝 참고사항

기간 처리 로직은 PeriodType (MONTHLY, SEMESTER)에 따라 Month 또는 Semester 필드를 동적으로 처리합니다.
📚 기타

관련 Swagger 문서 및 DTO 예제도 함께 수정되었습니다.