### PR TITLE
[Feat] AI 리포트 기능 개선

### DIFF
--- a/src/main/generated/com/example/SchoolLunchReport/aireport/entity/QReport.java
+++ b/src/main/generated/com/example/SchoolLunchReport/aireport/entity/QReport.java
@@ -23,6 +23,8 @@ public class QReport extends EntityPathBase<Report> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final StringPath name = createString("name");
+
     public final StringPath report = createString("report");
 
     public QReport(String variable) {

--- a/src/main/java/com/example/SchoolLunchReport/aireport/controller/AiReportController.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/controller/AiReportController.java
@@ -3,22 +3,29 @@ import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TE
 import com.example.SchoolLunchReport.aireport.dto.AiReportRequestDto;
 import com.example.SchoolLunchReport.aireport.dto.AiReportResponseDto;
 import com.example.SchoolLunchReport.aireport.dto.ReportDownloadRequestDto;
+import com.example.SchoolLunchReport.aireport.dto.ReportListResponseDto;
 import com.example.SchoolLunchReport.aireport.service.AiReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(ANALYTICS_TEAM_URL + "/aireport")
 @RequiredArgsConstructor
 public class AiReportController {
     private final AiReportService aiReportService;
+
+    @GetMapping("/get-all")
+    public ResponseEntity<List<ReportListResponseDto>> getAllReports() {
+        List<ReportListResponseDto> reports = aiReportService.getAllReports();
+        return ResponseEntity.ok(reports);
+    }
+
     @PostMapping("/generate")
     public ResponseEntity<AiReportResponseDto> generateReport(@RequestBody AiReportRequestDto requestDto) {
         AiReportResponseDto responseDto = aiReportService.generateReport(requestDto);

--- a/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/dto/AiReportRequestDto.java
@@ -1,9 +1,7 @@
 package com.example.SchoolLunchReport.aireport.dto;
-
 import lombok.Getter;
 import lombok.Setter;
 import java.time.LocalDate;
-
 @Getter
 @Setter
 public class AiReportRequestDto {

--- a/src/main/java/com/example/SchoolLunchReport/aireport/dto/ReportListResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/dto/ReportListResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.SchoolLunchReport.aireport.dto;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+@Getter
+@Builder
+public class ReportListResponseDto {
+    private Long id;
+    private String report;
+    private String name;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/SchoolLunchReport/aireport/entity/Report.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/entity/Report.java
@@ -19,6 +19,8 @@ public class Report {
     private Long id;
     @Column(columnDefinition = "TEXT")
     private String report;
+    @Column
+    private String name;
     @CreatedDate
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/SchoolLunchReport/aireport/service/AiReportService.java
+++ b/src/main/java/com/example/SchoolLunchReport/aireport/service/AiReportService.java
@@ -3,6 +3,7 @@ package com.example.SchoolLunchReport.aireport.service;
 import com.example.SchoolLunchReport.aireport.dto.AiReportDataDto;
 import com.example.SchoolLunchReport.aireport.dto.AiReportRequestDto;
 import com.example.SchoolLunchReport.aireport.dto.AiReportResponseDto;
+import com.example.SchoolLunchReport.aireport.dto.ReportListResponseDto;
 import com.example.SchoolLunchReport.aireport.entity.Report;
 import com.example.SchoolLunchReport.aireport.repository.ReportRepository;
 import com.example.SchoolLunchReport.product.FoodMenu.domain.entity.FoodMenu;
@@ -58,6 +59,18 @@ public class AiReportService {
     private final RestTemplate restTemplate;
 
     private static final int MAX_DATA_COUNT = 100;
+
+    public List<ReportListResponseDto> getAllReports() {
+        List<Report> reports = reportRepository.findAll();
+        return reports.stream()
+                .map(report -> ReportListResponseDto.builder()
+                        .id(report.getId())
+                        .report(report.getReport())
+                        .name(report.getName())
+                        .createdAt(report.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
 
     public AiReportResponseDto generateReport(AiReportRequestDto requestDto) {
         try {
@@ -242,6 +255,7 @@ public class AiReportService {
             HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
 
             String djangoUrl = "http://k8s-msaservices-7d023f0bb9-676035063.ap-northeast-2.elb.amazonaws.com/api/team3/llmchatbot/create_report/";
+            // String djangoUrl = "http://127.0.0.1:8000/api/team3/llmchatbot/create_report/";
 
             ResponseEntity<Map> response = restTemplate.exchange(
                 djangoUrl,
@@ -255,8 +269,11 @@ public class AiReportService {
             String message = (String) response.getBody().get("message");
             String reportText = (String) response.getBody().get("report");
 
+            String name = "기간: " + reportData.getPeriod_data() + " 동안의 ai보고서";
+
             Report savedReport = reportRepository.save(Report.builder()
                 .report(reportText)
+                .name(name)
                 .build());
 
             return AiReportResponseDto.builder()


### PR DESCRIPTION
# AI 리포트 기능 개선

## 변경 사항 개요

AI 리포트 시스템의 기능을 개선 +  확장
리포트에 이름 부여, 전체 리포트 조회 API

## 구현 기능

### 1. 리포트 이름 필드 추가

- `Report` 엔티티에 `name` 필드를 추가하여 각 리포트에 의미 있는 이름을 부여할 수 있게 함
- 리포트 생성 시 "기간: ${start_date}~${end_date} 동안의 ai보고서" 형식으로 자동 이름 생성

```java
@Column
private String name;
```

### 2. 전체 리포트 조회 API 개발

- 모든 리포트의 정보(id, report 내용, name, createdAt)를 조회할 수 있는 REST API 엔드포인트 구현
- GET 요청으로 해당 정보 JSON 형태로 반환

```java
@GetMapping
public ResponseEntity> getAllReports() {
    List reports = aiReportService.getAllReports();
    return ResponseEntity.ok(reports);
}
```