### PR TITLE
[Feat] 음식 전체 카테고리별 조회하기

### DIFF
--- a/src/main/java/com/example/SchoolLunchReport/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/controller/ProductController.java
@@ -1,0 +1,30 @@
+package com.example.SchoolLunchReport.domain.product.controller;
+
+import static com.example.SchoolLunchReport.global.common.Constants.ANALYTICS_TEAM_URL;
+
+import com.example.SchoolLunchReport.domain.product.controller.dto.FoodListResponseDto;
+import com.example.SchoolLunchReport.domain.product.food.domain.type.Category;
+import com.example.SchoolLunchReport.domain.product.service.ProductFacade;
+import com.example.SchoolLunchReport.global.response.ApiResponse;
+import com.example.SchoolLunchReport.global.response.type.SuccessType;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(ANALYTICS_TEAM_URL + "/products")
+public class ProductController implements ProductControllerDocs {
+
+    final ProductFacade productFacade;
+
+    @Override
+    @GetMapping("/foods")
+    public ApiResponse<?> getFoodListAll() {
+        Map<Category, List<FoodListResponseDto>> menuListByCategory = productFacade.getMenuListByCategory();
+        return ApiResponse.success(SuccessType.SUCCESS, menuListByCategory);
+    }
+}

--- a/src/main/java/com/example/SchoolLunchReport/domain/product/controller/ProductControllerDocs.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/controller/ProductControllerDocs.java
@@ -1,0 +1,12 @@
+package com.example.SchoolLunchReport.domain.product.controller;
+
+import com.example.SchoolLunchReport.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Product 관련 API")
+public interface ProductControllerDocs {
+
+    @Operation(summary = "음식 전체 카테고리별 조회하기")
+    ApiResponse<?> getFoodListAll();
+}

--- a/src/main/java/com/example/SchoolLunchReport/domain/product/controller/dto/FoodListResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/controller/dto/FoodListResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.SchoolLunchReport.domain.product.controller.dto;
+
+import com.example.SchoolLunchReport.domain.product.food.domain.type.SubCategory;
+
+public record FoodListResponseDto(
+    SubCategory subCategory,
+    Long foodId,
+    String foodName
+) {
+
+}

--- a/src/main/java/com/example/SchoolLunchReport/domain/product/food/service/FoodService.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/food/service/FoodService.java
@@ -1,7 +1,8 @@
 package com.example.SchoolLunchReport.domain.product.food.service;
 
-import com.example.SchoolLunchReport.domain.product.food.support.FoodReader;
+import com.example.SchoolLunchReport.domain.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.domain.product.food.repository.dto.FoodFrequencyDto;
+import com.example.SchoolLunchReport.domain.product.food.support.FoodReader;
 import com.example.SchoolLunchReport.domain.statistics.domain.boundary.entity.Boundary;
 import java.util.Comparator;
 import java.util.List;
@@ -20,5 +21,9 @@ public class FoodService {
         return foodReader.getFoodFrequencyInBoundary(boundary).stream()
             .sorted(Comparator.comparing(FoodFrequencyDto::category))
             .collect(Collectors.toList());
+    }
+
+    public List<Food> getFoodList() {
+        return foodReader.getFoodAll();
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/domain/product/food/support/FoodReader.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/food/support/FoodReader.java
@@ -7,7 +7,9 @@ import com.example.SchoolLunchReport.domain.product.food.repository.FoodJpaRepos
 import com.example.SchoolLunchReport.domain.product.food.repository.dto.FoodFrequencyDto;
 import com.example.SchoolLunchReport.domain.statistics.domain.boundary.entity.Boundary;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -40,5 +42,15 @@ public class FoodReader {
         return foodJpaRepository.findById(foodId).orElseThrow(
             () -> new EntityNotFoundException("없는 음식 아이디입니다")
         );
+    }
+
+    public List<Food> getFoodAll() {
+        return new ArrayList<>(foodJpaRepository.findAll().stream()
+            .collect(Collectors.toMap(
+                Food::getName,
+                food -> food,
+                (f1, f2) -> f1
+            ))
+            .values());
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/domain/product/service/ProductFacade.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/product/service/ProductFacade.java
@@ -1,0 +1,48 @@
+package com.example.SchoolLunchReport.domain.product.service;
+
+import com.example.SchoolLunchReport.domain.product.controller.dto.FoodListResponseDto;
+import com.example.SchoolLunchReport.domain.product.food.domain.entity.Food;
+import com.example.SchoolLunchReport.domain.product.food.domain.type.Category;
+import com.example.SchoolLunchReport.domain.product.food.service.FoodService;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductFacade {
+
+    final FoodService foodService;
+
+    public Map<Category, List<FoodListResponseDto>> getMenuListByCategory() {
+        List<Category> categoryOrder = List.of(
+            Category.RICE,
+            Category.MAIN_DISH,
+            Category.SIDE_DISH,
+            Category.DESSERT
+        );
+
+        List<Food> foodList = foodService.getFoodList();
+
+        Map<Category, List<FoodListResponseDto>> grouped = foodList.stream()
+            .collect(Collectors.groupingBy(
+                Food::getCategory,
+                Collectors.mapping(
+                    f -> new FoodListResponseDto(f.getSubCategory(), f.getId(), f.getName()),
+                    Collectors.toList()
+                )
+            ));
+
+        Map<Category, List<FoodListResponseDto>> orderedMap = new LinkedHashMap<>();
+        for (Category category : categoryOrder) {
+            List<FoodListResponseDto> items = grouped.getOrDefault(category,
+                Collections.emptyList());
+            orderedMap.put(category, items);
+        }
+        return orderedMap;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

---

- close : #이슈번호

## 📌 작업 내용 및 특이사항

데이터베이스에 Food가 중복으로 저장된 경우가 있습니다.
데이터 초기화할 때 발생한 문제이지만 메뉴와 연결되어있고, 그걸 지우면 피드백도 지워야하는 상태라, 데이터를 위해 
중복을 냅두고 조회할 때 필터링을 하는 방식으로 해결했습니다.

---

## 📝 참고사항

-

--- 

## 📚 기타

-

---
