### PR TITLE
[Refactor] 건의함 등록, 수정할 떄 음식 id가 아닌 음식 명으로 받기

### DIFF
--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/request/CreateSuggestionRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/request/CreateSuggestionRequestDto.java
@@ -1,6 +1,5 @@
 package com.example.SchoolLunchReport.domain.suggestion.controller.dto.request;
 
-import com.example.SchoolLunchReport.domain.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.domain.product.food.domain.type.Category;
 import com.example.SchoolLunchReport.domain.suggestion.domain.entity.Suggestion;
 
@@ -9,17 +8,17 @@ public record CreateSuggestionRequestDto(
     String nickName,
     Category category,
     String content,
-    Long foodId
+    String foodName
 ) {
 
-    public Suggestion toEntity(Food food) {
+    public Suggestion toEntity() {
         return Suggestion
             .builder()
             .title(title)
             .nickName(nickName)
             .category(category)
             .content(content)
-            .food(food)
+            .foodName(foodName)
             .build();
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/request/UpdateSuggestionRequestDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/request/UpdateSuggestionRequestDto.java
@@ -7,7 +7,7 @@ public record UpdateSuggestionRequestDto(
     String nickName,
     Category category,
     String content,
-    Long foodId
+    String foodName
 ) {
 
 }

--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/response/SuggestionListItemResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/response/SuggestionListItemResponseDto.java
@@ -12,7 +12,7 @@ public record SuggestionListItemResponseDto(
     String title,
     String nickName,
     Category category,
-    @JsonFormat(pattern = "YYYY-MM-DD")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate createAt
 ) {
 

--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/response/SuggestionResponseDto.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/controller/dto/response/SuggestionResponseDto.java
@@ -13,7 +13,7 @@ public record SuggestionResponseDto(
     String nickName,
     Category category,
     String content,
-    @JsonFormat(pattern = "YYYY-MM-DD")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate createAt
 ) {
 

--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/domain/entity/Suggestion.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/domain/entity/Suggestion.java
@@ -1,6 +1,5 @@
 package com.example.SchoolLunchReport.domain.suggestion.domain.entity;
 
-import com.example.SchoolLunchReport.domain.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.domain.product.food.domain.type.Category;
 import com.example.SchoolLunchReport.domain.suggestion.controller.dto.request.UpdateSuggestionRequestDto;
 import com.example.SchoolLunchReport.global.common.BaseTimeEntity;
@@ -9,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,24 +32,24 @@ public class Suggestion extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    @ManyToOne(optional = true)
-    private Food food;
+    @Column(nullable = false)
+    private String foodName;
 
     @Builder
     public Suggestion(String title, String nickName, Category category, String content,
-        Food food) {
+        String foodName) {
         this.title = title;
         this.nickName = nickName;
         this.category = category;
         this.content = content;
-        this.food = food;
+        this.foodName = foodName;
     }
 
-    public void update(UpdateSuggestionRequestDto updateSuggestionRequestDto, Food food) {
+    public void update(UpdateSuggestionRequestDto updateSuggestionRequestDto) {
         this.title = updateSuggestionRequestDto.title();
         this.nickName = updateSuggestionRequestDto.nickName();
         this.category = updateSuggestionRequestDto.category();
         this.content = updateSuggestionRequestDto.content();
-        this.food = food;
+        this.foodName = updateSuggestionRequestDto.foodName();
     }
 }

--- a/src/main/java/com/example/SchoolLunchReport/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/com/example/SchoolLunchReport/domain/suggestion/service/SuggestionService.java
@@ -1,6 +1,5 @@
 package com.example.SchoolLunchReport.domain.suggestion.service;
 
-import com.example.SchoolLunchReport.domain.product.food.domain.entity.Food;
 import com.example.SchoolLunchReport.domain.product.food.support.FoodReader;
 import com.example.SchoolLunchReport.domain.suggestion.controller.dto.request.CreateSuggestionRequestDto;
 import com.example.SchoolLunchReport.domain.suggestion.controller.dto.request.SuggestionSpecRequestDto;
@@ -19,7 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional()
+@Transactional
 @RequiredArgsConstructor
 public class SuggestionService {
 
@@ -27,8 +26,7 @@ public class SuggestionService {
     final FoodReader foodReader;
 
     public String createSuggestion(CreateSuggestionRequestDto createSuggestionRequestDto) {
-        Food food = foodReader.getFoodById(createSuggestionRequestDto.foodId());
-        Suggestion suggestion = createSuggestionRequestDto.toEntity(food);
+        Suggestion suggestion = createSuggestionRequestDto.toEntity();
         suggestionJpaRepo.save(suggestion);
         return suggestion.getTitle();
     }
@@ -53,9 +51,8 @@ public class SuggestionService {
         Long suggestionId,
         UpdateSuggestionRequestDto updateSuggestionRequestDto
     ) {
-        Food food = foodReader.getFoodById(updateSuggestionRequestDto.foodId());
         Suggestion suggestion = findSuggestionById(suggestionId);
-        suggestion.update(updateSuggestionRequestDto, food);
+        suggestion.update(updateSuggestionRequestDto);
         return SuggestionResponseDto.toEntity(suggestion);
 
     }
@@ -67,7 +64,7 @@ public class SuggestionService {
             .id(suggestionId)
             .build();
     }
-
+    
     private Suggestion findSuggestionById(Long suggestionId) {
         return suggestionJpaRepo.findById(suggestionId).orElseThrow(
             () -> new EntityNotFoundException("존재하지 않는 건의입니다.")


### PR DESCRIPTION
## 🌱 관련 이슈

---

- close : #이슈번호

## 📌 작업 내용 및 특이사항
원래는 음식을 선택하여 우리 서비스가 제공하는 음식에 대한 건의를 작성하는 로직이였습니다.
하지만 음식 전체 조회 API가 빠져서 다음주 데모에 그렇게 변경하도록 하고 음식명으로 자유형식으로 받기로 했습니다.
그래서 이번 데모 후 수정 예정입니다.
-

---

## 📝 참고사항

-

--- 

## 📚 기타

-

---
